### PR TITLE
Add some missing mod_loaded recipe conditions for Quark items.

### DIFF
--- a/src/main/resources/data/ecologics/recipes/quark/azalea_trapped_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/azalea_trapped_chest.json
@@ -10,5 +10,15 @@
   ],
   "result": {
     "item": "ecologics:azalea_trapped_chest"
-  }
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    },
+    {
+      "type": "quark:flag",
+      "flag": "variant_chests"
+    }
+  ]
 }

--- a/src/main/resources/data/ecologics/recipes/quark/azalea_wood_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/azalea_wood_chest.json
@@ -19,6 +19,10 @@
             "type": "forge:and",
             "values": [
                 {
+                    "type": "forge:mod_loaded",
+                    "modid": "quark"
+                },
+                {
                     "type": "ecologics:quark_flag",
                     "flag": "wood_to_chest_recipes"
                 },

--- a/src/main/resources/data/ecologics/recipes/quark/coconut_leaf_carpet.json
+++ b/src/main/resources/data/ecologics/recipes/quark/coconut_leaf_carpet.json
@@ -14,6 +14,10 @@
   },
   "conditions": [
     {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    },
+    {
       "type": "quark:flag",
       "flag": "leaf_carpet"
     }

--- a/src/main/resources/data/ecologics/recipes/quark/coconut_trapped_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/coconut_trapped_chest.json
@@ -10,5 +10,15 @@
   ],
   "result": {
     "item": "ecologics:coconut_trapped_chest"
-  }
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    },
+    {
+      "type": "quark:flag",
+      "flag": "variant_chests"
+    }
+  ]
 }

--- a/src/main/resources/data/ecologics/recipes/quark/coconut_wood_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/coconut_wood_chest.json
@@ -19,6 +19,10 @@
             "type": "forge:and",
             "values": [
                 {
+                    "type": "forge:mod_loaded",
+                    "modid": "quark"
+                },
+                {
                     "type": "ecologics:quark_flag",
                     "flag": "wood_to_chest_recipes"
                 },

--- a/src/main/resources/data/ecologics/recipes/quark/flowering_azalea_trapped_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/flowering_azalea_trapped_chest.json
@@ -10,5 +10,15 @@
   ],
   "result": {
     "item": "ecologics:flowering_azalea_trapped_chest"
-  }
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    },
+    {
+      "type": "quark:flag",
+      "flag": "variant_chests"
+    }
+  ]
 }

--- a/src/main/resources/data/ecologics/recipes/quark/flowering_azalea_wood_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/flowering_azalea_wood_chest.json
@@ -19,6 +19,10 @@
             "type": "forge:and",
             "values": [
                 {
+                    "type": "forge:mod_loaded",
+                    "modid": "quark"
+                },
+                {
                     "type": "ecologics:quark_flag",
                     "flag": "wood_to_chest_recipes"
                 },

--- a/src/main/resources/data/ecologics/recipes/quark/walnut_leaf_carpet.json
+++ b/src/main/resources/data/ecologics/recipes/quark/walnut_leaf_carpet.json
@@ -14,6 +14,10 @@
   },
   "conditions": [
     {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    },
+    {
       "type": "quark:flag",
       "flag": "leaf_carpet"
     }

--- a/src/main/resources/data/ecologics/recipes/quark/walnut_trapped_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/walnut_trapped_chest.json
@@ -10,5 +10,15 @@
   ],
   "result": {
     "item": "ecologics:walnut_trapped_chest"
-  }
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    },
+    {
+      "type": "quark:flag",
+      "flag": "variant_chests"
+    }
+  ]
 }

--- a/src/main/resources/data/ecologics/recipes/quark/walnut_wood_chest.json
+++ b/src/main/resources/data/ecologics/recipes/quark/walnut_wood_chest.json
@@ -19,6 +19,10 @@
             "type": "forge:and",
             "values": [
                 {
+                    "type": "forge:mod_loaded",
+                    "modid": "quark"
+                },
+                {
                     "type": "ecologics:quark_flag",
                     "flag": "wood_to_chest_recipes"
                 },


### PR DESCRIPTION
Should fix all of the missing recipe errors seen in #48 
The rest of the errors in that report are covered by #39 loot table fixes.