### PR TITLE
Prevent penguins from freezing to death, and allow penguins + squirrels to walk over powder snow.

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/entity_types/freeze_immune_entity_types.json
+++ b/common/src/main/resources/data/minecraft/tags/entity_types/freeze_immune_entity_types.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ecologics:penguin"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/entity_types/powder_snow_walkable_mobs.json
+++ b/common/src/main/resources/data/minecraft/tags/entity_types/powder_snow_walkable_mobs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ecologics:penguin"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/entity_types/powder_snow_walkable_mobs.json
+++ b/common/src/main/resources/data/minecraft/tags/entity_types/powder_snow_walkable_mobs.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "ecologics:penguin"
+    "ecologics:penguin",
+    "ecologics:squirrel"
   ]
 }


### PR DESCRIPTION
Feels natural that penguins should be immune to freezing (in line with other Minecraft mobs like the Polar Bear).

Similarly, mobs like Foxes and Rabbits can walk over powder snow, so it seems like other small mobs should be able to as well.

This should probably be backported to the other branches as well, but I'll leave that up to you.