### PR TITLE
bring back oak trees in plains, add walnut trees to sunflower plains

### DIFF
--- a/forge/src/main/resources/data/ecologics/forge/biome_modifier/add_walnut_tree.json
+++ b/forge/src/main/resources/data/ecologics/forge/biome_modifier/add_walnut_tree.json
@@ -1,6 +1,9 @@
 {
   "type": "forge:add_features",
-  "biomes": "minecraft:plains",
+  "biomes": [
+    "minecraft:plains",
+    "minecraft:sunflower_plains"
+  ],
   "features": "ecologics:trees_walnut",
   "step": "vegetal_decoration"
 }

--- a/forge/src/main/resources/data/ecologics/forge/biome_modifier/remove_classic_vines_cave_feature.json
+++ b/forge/src/main/resources/data/ecologics/forge/biome_modifier/remove_classic_vines_cave_feature.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:remove_features",
-  "biomes": "minecraft:lush_caves",
-  "features": "minecraft:classic_vines_cave_feature",
-  "step": "vegetal_decoration"
-}

--- a/forge/src/main/resources/data/ecologics/forge/biome_modifier/remove_trees_plains.json
+++ b/forge/src/main/resources/data/ecologics/forge/biome_modifier/remove_trees_plains.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:remove_features",
-  "biomes": "minecraft:plains",
-  "features": "minecraft:trees_plains",
-  "step": "vegetal_decoration"
-}


### PR DESCRIPTION
The oak trees are removed by default in the plain biome. I think they should be brought back. It would prevent to have to use a datapack just for bringing back. Also I noticed that the cave vines are also removed, I'm unsure why. I decided to also bring them back.