### PR TITLE
Adding farmers delight axe cutting recipes for wooden items

### DIFF
--- a/common/src/main/resources/data/ecologics/recipes/cutting/azalea_door.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/azalea_door.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:azalea_trapdoor"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/azalea_hanging_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/azalea_hanging_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:azalea_hanging_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/azalea_log.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/azalea_log.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:azalea_log"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_azalea_log"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/azalea_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/azalea_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:azalea_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/azalea_trapdoor.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/azalea_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:azalea_door"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/azalea_wood.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/azalea_wood.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:azalea_wood"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_azalea_wood"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/coconut_door.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/coconut_door.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:coconut_trapdoor"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:coconut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/coconut_hanging_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/coconut_hanging_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:coconut_hanging_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:coconut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/coconut_log.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/coconut_log.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:coconut_log"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_coconut_log"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/coconut_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/coconut_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:coconut_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:coconut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/coconut_trapdoor.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/coconut_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:coconut_door"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:coconut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/coconut_wood.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/coconut_wood.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:coconut_wood"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_coconut_wood"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_door.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_door.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:flowering_azalea_trapdoor"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:flowering_azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_hanging_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_hanging_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:flowering_azalea_hanging_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:flowering_azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_log.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_log.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:flowering_azalea_log"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_azalea_log"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:flowering_azalea_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:flowering_azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_trapdoor.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:flowering_azalea_door"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:flowering_azalea_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_wood.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/flowering_azalea_wood.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:flowering_azalea_wood"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_azalea_wood"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/walnut_door.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/walnut_door.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:walnut_trapdoor"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:walnut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/walnut_hanging_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/walnut_hanging_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:walnut_hanging_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:walnut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/walnut_log.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/walnut_log.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:walnut_log"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_walnut_log"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/walnut_sign.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/walnut_sign.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:walnut_sign"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:walnut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/walnut_trapdoor.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/walnut_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:walnut_door"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:walnut_planks"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_dig"
+  }
+}

--- a/common/src/main/resources/data/ecologics/recipes/cutting/walnut_wood.json
+++ b/common/src/main/resources/data/ecologics/recipes/cutting/walnut_wood.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "ecologics:walnut_wood"
+    }
+  ],
+  "result": [
+    {
+      "item": "ecologics:stripped_walnut_wood"
+    },
+    {
+      "item": "farmersdelight:tree_bark"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "tool": {
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
+  }
+}


### PR DESCRIPTION
This might be a change that's more suited for a mod light [Delightful](https://github.com/brnbrd/Delightful), but I figured I'd make the PR here.

This PR is a simple datapack change that adds recipes equivalent recipes for the wood recipes in Farmer's Delight.