### PR TITLE
adding common tags to various recipes

### DIFF
--- a/common/src/main/resources/data/ecologics/recipe/azalea_chest_boat.json
+++ b/common/src/main/resources/data/ecologics/recipe/azalea_chest_boat.json
@@ -1,17 +1,17 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
-  "group": "chest_boat",
-  "ingredients": [
-    {
-      "item": "minecraft:chest"
-    },
-    {
-      "item": "ecologics:azalea_boat"
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "group": "chest_boat",
+    "ingredients": [
+        {
+            "tag": "c:chests/wooden"
+        },
+        {
+            "item": "ecologics:azalea_boat"
+        }
+    ],
+    "result": {
+        "count": 1,
+        "id": "ecologics:azalea_chest_boat"
     }
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:azalea_chest_boat"
-  }
 }

--- a/common/src/main/resources/data/ecologics/recipe/azalea_fence.json
+++ b/common/src/main/resources/data/ecologics/recipe/azalea_fence.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_fence",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:azalea_planks"
-    }
-  },
-  "pattern": [
-    "W#W",
-    "W#W"
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:azalea_fence"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_fence",
+	"pattern": [
+		"W#W",
+		"W#W"
+	],
+	"key": {
+		"W": {
+			"item": "ecologics:azalea_planks"
+		},
+		"#": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:azalea_fence"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/azalea_fence_gate.json
+++ b/common/src/main/resources/data/ecologics/recipe/azalea_fence_gate.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "redstone",
-  "group": "wooden_fence_gate",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:azalea_planks"
-    }
-  },
-  "pattern": [
-    "#W#",
-    "#W#"
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:azalea_fence_gate"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "redstone",
+	"group": "wooden_fence_gate",
+	"pattern": [
+		"#W#",
+		"#W#"
+	],
+	"key": {
+		"#": {
+			"tag": "c:rods/wooden"
+		},
+		"W": {
+			"item": "ecologics:azalea_planks"
+		}
+	},
+	"result": {
+		"count": 1,
+		"id": "ecologics:azalea_fence_gate"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/azalea_sign.json
+++ b/common/src/main/resources/data/ecologics/recipe/azalea_sign.json
@@ -1,22 +1,22 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_sign",
-  "key": {
-    "#": {
-      "item": "ecologics:azalea_planks"
-    },
-    "X": {
-      "item": "minecraft:stick"
-    }
-  },
-  "pattern": [
-    "###",
-    "###",
-    " X "
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:azalea_sign"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_sign",
+	"pattern": [
+		"###",
+		"###",
+		" X "
+	],
+	"key": {
+		"#": {
+			"item": "ecologics:azalea_planks"
+		},
+		"X": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:azalea_sign"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/coconut_chest_boat.json
+++ b/common/src/main/resources/data/ecologics/recipe/coconut_chest_boat.json
@@ -1,17 +1,17 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
-  "group": "chest_boat",
-  "ingredients": [
-    {
-      "item": "minecraft:chest"
-    },
-    {
-      "item": "ecologics:coconut_boat"
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "group": "chest_boat",
+    "ingredients": [
+        {
+            "tag": "c:chests/wooden"
+        },
+        {
+            "item": "ecologics:coconut_boat"
+        }
+    ],
+    "result": {
+        "count": 1,
+        "id": "ecologics:coconut_chest_boat"
     }
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:coconut_chest_boat"
-  }
 }

--- a/common/src/main/resources/data/ecologics/recipe/coconut_fence.json
+++ b/common/src/main/resources/data/ecologics/recipe/coconut_fence.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_fence",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:coconut_planks"
-    }
-  },
-  "pattern": [
-    "W#W",
-    "W#W"
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:coconut_fence"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_fence",
+	"pattern": [
+		"W#W",
+		"W#W"
+	],
+	"key": {
+		"W": {
+			"item": "ecologics:coconut_planks"
+		},
+		"#": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:coconut_fence"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/coconut_fence_gate.json
+++ b/common/src/main/resources/data/ecologics/recipe/coconut_fence_gate.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "redstone",
-  "group": "wooden_fence_gate",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:coconut_planks"
-    }
-  },
-  "pattern": [
-    "#W#",
-    "#W#"
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:coconut_fence_gate"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "redstone",
+	"group": "wooden_fence_gate",
+	"pattern": [
+		"#W#",
+		"#W#"
+	],
+	"key": {
+		"#": {
+			"tag": "c:rods/wooden"
+		},
+		"W": {
+			"item": "ecologics:coconut_planks"
+		}
+	},
+	"result": {
+		"count": 1,
+		"id": "ecologics:coconut_fence_gate"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/coconut_sign.json
+++ b/common/src/main/resources/data/ecologics/recipe/coconut_sign.json
@@ -1,22 +1,22 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_sign",
-  "key": {
-    "#": {
-      "item": "ecologics:coconut_planks"
-    },
-    "X": {
-      "item": "minecraft:stick"
-    }
-  },
-  "pattern": [
-    "###",
-    "###",
-    " X "
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:coconut_sign"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_sign",
+	"pattern": [
+		"###",
+		"###",
+		" X "
+	],
+	"key": {
+		"#": {
+			"item": "ecologics:coconut_planks"
+		},
+		"X": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:coconut_sign"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/flowering_azalea_chest_boat.json
+++ b/common/src/main/resources/data/ecologics/recipe/flowering_azalea_chest_boat.json
@@ -1,17 +1,17 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
-  "group": "chest_boat",
-  "ingredients": [
-    {
-      "item": "minecraft:chest"
-    },
-    {
-      "item": "ecologics:flowering_azalea_boat"
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "group": "chest_boat",
+    "ingredients": [
+        {
+            "tag": "c:chests/wooden"
+        },
+        {
+            "item": "ecologics:flowering_azalea_boat"
+        }
+    ],
+    "result": {
+        "count": 1,
+        "id": "ecologics:flowering_azalea_chest_boat"
     }
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:flowering_azalea_chest_boat"
-  }
 }

--- a/common/src/main/resources/data/ecologics/recipe/flowering_azalea_fence.json
+++ b/common/src/main/resources/data/ecologics/recipe/flowering_azalea_fence.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_fence",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:flowering_azalea_planks"
-    }
-  },
-  "pattern": [
-    "W#W",
-    "W#W"
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:flowering_azalea_fence"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_fence",
+	"pattern": [
+		"W#W",
+		"W#W"
+	],
+	"key": {
+		"W": {
+			"item": "ecologics:flowering_azalea_planks"
+		},
+		"#": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:flowering_azalea_fence"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/flowering_azalea_fence_gate.json
+++ b/common/src/main/resources/data/ecologics/recipe/flowering_azalea_fence_gate.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "redstone",
-  "group": "wooden_fence_gate",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:flowering_azalea_planks"
-    }
-  },
-  "pattern": [
-    "#W#",
-    "#W#"
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:flowering_azalea_fence_gate"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "redstone",
+	"group": "wooden_fence_gate",
+	"pattern": [
+		"#W#",
+		"#W#"
+	],
+	"key": {
+		"#": {
+			"tag": "c:rods/wooden"
+		},
+		"W": {
+			"item": "ecologics:flowering_azalea_planks"
+		}
+	},
+	"result": {
+		"count": 1,
+		"id": "ecologics:flowering_azalea_fence_gate"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/flowering_azalea_sign.json
+++ b/common/src/main/resources/data/ecologics/recipe/flowering_azalea_sign.json
@@ -1,22 +1,22 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_sign",
-  "key": {
-    "#": {
-      "item": "ecologics:flowering_azalea_planks"
-    },
-    "X": {
-      "item": "minecraft:stick"
-    }
-  },
-  "pattern": [
-    "###",
-    "###",
-    " X "
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:flowering_azalea_sign"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_sign",
+	"pattern": [
+		"###",
+		"###",
+		" X "
+	],
+	"key": {
+		"#": {
+			"item": "ecologics:flowering_azalea_planks"
+		},
+		"X": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:flowering_azalea_sign"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/sandcastle.json
+++ b/common/src/main/resources/data/ecologics/recipe/sandcastle.json
@@ -1,24 +1,24 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "key": {
-    "A": {
-      "item": "minecraft:sand"
-    },
-    "B": {
-      "item": "ecologics:seashell"
-    },
-    "C": {
-      "item": "minecraft:stick"
-    }
-  },
-  "pattern": [
-    " C ",
-    "ABA",
-    "AAA"
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:sandcastle"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"pattern": [
+		" C ",
+		"ABA",
+		"AAA"
+	],
+	"key": {
+		"C": {
+			"tag": "c:rods/wooden"
+		},
+		"A": {
+			"item": "minecraft:sand"
+		},
+		"B": {
+			"item": "ecologics:seashell"
+		}
+	},
+	"result": {
+		"count": 1,
+		"id": "ecologics:sandcastle"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/walnut_chest_boat.json
+++ b/common/src/main/resources/data/ecologics/recipe/walnut_chest_boat.json
@@ -1,17 +1,17 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
-  "group": "chest_boat",
-  "ingredients": [
-    {
-      "item": "minecraft:chest"
-    },
-    {
-      "item": "ecologics:walnut_boat"
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "group": "chest_boat",
+    "ingredients": [
+        {
+            "tag": "c:chests/wooden"
+        },
+        {
+            "item": "ecologics:walnut_boat"
+        }
+    ],
+    "result": {
+        "count": 1,
+        "id": "ecologics:walnut_chest_boat"
     }
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:walnut_chest_boat"
-  }
 }

--- a/common/src/main/resources/data/ecologics/recipe/walnut_fence.json
+++ b/common/src/main/resources/data/ecologics/recipe/walnut_fence.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_fence",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:walnut_planks"
-    }
-  },
-  "pattern": [
-    "W#W",
-    "W#W"
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:walnut_fence"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_fence",
+	"pattern": [
+		"W#W",
+		"W#W"
+	],
+	"key": {
+		"W": {
+			"item": "ecologics:walnut_planks"
+		},
+		"#": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:walnut_fence"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/walnut_fence_gate.json
+++ b/common/src/main/resources/data/ecologics/recipe/walnut_fence_gate.json
@@ -1,21 +1,21 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "redstone",
-  "group": "wooden_fence_gate",
-  "key": {
-    "#": {
-      "item": "minecraft:stick"
-    },
-    "W": {
-      "item": "ecologics:walnut_planks"
-    }
-  },
-  "pattern": [
-    "#W#",
-    "#W#"
-  ],
-  "result": {
-    "count": 1, 
-    "id": "ecologics:walnut_fence_gate"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "redstone",
+	"group": "wooden_fence_gate",
+	"pattern": [
+		"#W#",
+		"#W#"
+	],
+	"key": {
+		"#": {
+			"tag": "c:rods/wooden"
+		},
+		"W": {
+			"item": "ecologics:walnut_planks"
+		}
+	},
+	"result": {
+		"count": 1,
+		"id": "ecologics:walnut_fence_gate"
+	}
 }

--- a/common/src/main/resources/data/ecologics/recipe/walnut_sign.json
+++ b/common/src/main/resources/data/ecologics/recipe/walnut_sign.json
@@ -1,22 +1,22 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "wooden_sign",
-  "key": {
-    "#": {
-      "item": "ecologics:walnut_planks"
-    },
-    "X": {
-      "item": "minecraft:stick"
-    }
-  },
-  "pattern": [
-    "###",
-    "###",
-    " X "
-  ],
-  "result": {
-    "count": 3,
-    "id": "ecologics:walnut_sign"
-  }
+	"type": "minecraft:crafting_shaped",
+	"category": "misc",
+	"group": "wooden_sign",
+	"pattern": [
+		"###",
+		"###",
+		" X "
+	],
+	"key": {
+		"#": {
+			"item": "ecologics:walnut_planks"
+		},
+		"X": {
+			"tag": "c:rods/wooden"
+		}
+	},
+	"result": {
+		"count": 3,
+		"id": "ecologics:walnut_sign"
+	}
 }


### PR DESCRIPTION
this PR adds `c:rods/wooden` in place of `minecraft:stick` and `c:chests/wooden` in place of `minecraft:chest` to various recipes adding better compatibility with other mods.

<img width="370" height="114" alt="image" src="https://github.com/user-attachments/assets/34880942-5979-4ec0-87b7-9efc21a2b06e" />